### PR TITLE
Escape HTML entities in diff controller. fixes #93

### DIFF
--- a/Classes/DiffController.m
+++ b/Classes/DiffController.m
@@ -1,4 +1,5 @@
 #import "DiffController.h"
+#import "NSString+Extensions.h"
 
 
 @interface DiffController ()
@@ -49,7 +50,8 @@
 }
 
 - (NSString *)htmlFormatDiff:(NSString *)theDiff {
-	NSArray *lines = [theDiff componentsSeparatedByString:@"\n"];
+    NSString *escaped = [theDiff escapeHTML];
+	NSArray *lines = [escaped componentsSeparatedByString:@"\n"];
 	NSMutableString *diff = [NSMutableString string];
 	for (NSString *line in lines) {
 		if ([line hasPrefix:@"@@"]) {

--- a/Classes/Extensions/NSString+Extensions.h
+++ b/Classes/Extensions/NSString+Extensions.h
@@ -4,4 +4,5 @@
 @interface NSString (Extensions)
 - (NSString *)lowercaseFirstCharacter;
 - (BOOL)isEmpty;
+- (NSString *)escapeHTML;
 @end

--- a/Classes/Extensions/NSString+Extensions.m
+++ b/Classes/Extensions/NSString+Extensions.m
@@ -15,4 +15,14 @@
 	return [trimmed isEqualToString:@""];
 }
 
+- (NSString *)escapeHTML {
+    NSMutableString *result = [[NSMutableString alloc] initWithString:self];
+    [result replaceOccurrencesOfString:@"&" withString:@"&amp;" options:NSLiteralSearch range:NSMakeRange(0, [result length])];
+    [result replaceOccurrencesOfString:@"<" withString:@"&lt;" options:NSLiteralSearch range:NSMakeRange(0, [result length])];
+    [result replaceOccurrencesOfString:@">" withString:@"&gt;" options:NSLiteralSearch range:NSMakeRange(0, [result length])];
+    [result replaceOccurrencesOfString:@"\"" withString:@"&quot;" options:NSLiteralSearch range:NSMakeRange(0, [result length])];
+    [result replaceOccurrencesOfString:@"'" withString:@"&#39;" options:NSLiteralSearch range:NSMakeRange(0, [result length])];
+    return [result autorelease];
+}
+
 @end


### PR DESCRIPTION
Sorry for tabs vs spaces. Browsing code in TextMate reveals that it's a common problem with Xcode. Damn you, Xcode!
