### PR TITLE
missing login/password should not map to nil

### DIFF
--- a/Classes/LoginController.m
+++ b/Classes/LoginController.m
@@ -106,7 +106,7 @@
             [self finishAuthenticating];
         } else {
             [self presentLogin];
-            [self failWithMessage:@"Please ensure that you are connected to the internet and that your login and API token are correct"];
+            [self failWithMessage:@"Please ensure that you are connected to the internet and that your login and password are correct"];
         }
     }
 }

--- a/Classes/LoginController.m
+++ b/Classes/LoginController.m
@@ -4,6 +4,7 @@
 
 
 @interface LoginController ()
++ (NSString *)stringFromUserDefaults:(NSUserDefaults *)defaults forKey:(NSString *)key defaultsTo:(NSString *)defaultValue;
 - (void)presentLogin;
 - (void)dismissLogin;
 - (void)showAuthenticationSheet;
@@ -21,6 +22,11 @@
 @synthesize delegate;
 @synthesize user;
 
++ (NSString *)stringFromUserDefaults:(NSUserDefaults *)defaults forKey:(NSString *)key defaultsTo:(NSString *)defaultValue {
+	NSString *value = [defaults stringForKey:key];
+	return value != nil ? value : defaultValue;
+}
+
 - (id)initWithViewController:(UIViewController *)theViewController {
 	[super initWithNibName:@"Login" bundle:nil];
     viewController = theViewController;
@@ -30,8 +36,8 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-	loginField.text = [defaults valueForKey:kLoginDefaultsKey];
-	passwordField.text = [defaults valueForKey:kPasswordDefaultsKey];
+	loginField.text = [LoginController stringFromUserDefaults:defaults forKey:kLoginDefaultsKey defaultsTo:@""];
+	passwordField.text = [LoginController stringFromUserDefaults:defaults forKey:kPasswordDefaultsKey defaultsTo:@""];
 	loginField.clearButtonMode = UITextFieldViewModeWhileEditing;
 	passwordField.clearButtonMode = UITextFieldViewModeWhileEditing;
 }


### PR DESCRIPTION
Hi Dennis,
if the login/password is missing in the user defaults, it gets mapped to nil and the login button can only be pressed once and is deactivated afterwards.
The attached change maps missing login/password defaults to an empty string.
Arne
