### PR TITLE
Section the accounts table view by endpoint

### DIFF
--- a/Classes/iOctocat.m
+++ b/Classes/iOctocat.m
@@ -59,6 +59,9 @@
 }
 
 - (void)setCurrentAccount:(GHAccount *)account {
+	self.users = [NSMutableDictionary dictionary];
+	self.organizations = [NSMutableDictionary dictionary];
+
 	_currentAccount = account;
 	if (!self.currentAccount) {
 		UIBarButtonItem *btnItem = self.menuNavController.topViewController.navigationItem.rightBarButtonItem;


### PR DESCRIPTION
These sections make it easy to see which logins belong to which github
endpoints. It is not uncommon for someone to have the same login on github.com
as they do on an enterprise github installation. Fixed a problem in this
situation where the sliding view would show data for the first account listed
if it had the same login as the selected account. Also cleared out the user
and organization caches when the account is changed.
